### PR TITLE
Add alias option into various services and update helper

### DIFF
--- a/docs/resources/chickhouse.md
+++ b/docs/resources/chickhouse.md
@@ -18,5 +18,3 @@ description: |-
 ### Required
 
 - `service_name` (String) Service name to create
-
-

--- a/docs/resources/clickhouse_link.md
+++ b/docs/resources/clickhouse_link.md
@@ -20,4 +20,6 @@ description: |-
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
 
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL

--- a/docs/resources/couchdb.md
+++ b/docs/resources/couchdb.md
@@ -18,5 +18,3 @@ description: |-
 ### Required
 
 - `service_name` (String) Service name to create
-
-

--- a/docs/resources/couchdb_link.md
+++ b/docs/resources/couchdb_link.md
@@ -20,4 +20,6 @@ description: |-
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
 
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL

--- a/docs/resources/elasticsearch.md
+++ b/docs/resources/elasticsearch.md
@@ -18,5 +18,3 @@ description: |-
 ### Required
 
 - `service_name` (String) Service name to create
-
-

--- a/docs/resources/elasticsearch_link.md
+++ b/docs/resources/elasticsearch_link.md
@@ -20,4 +20,6 @@ description: |-
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
 
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL

--- a/docs/resources/mariadb.md
+++ b/docs/resources/mariadb.md
@@ -18,5 +18,3 @@ description: |-
 ### Required
 
 - `service_name` (String) Service name to create
-
-

--- a/docs/resources/mariadb_link.md
+++ b/docs/resources/mariadb_link.md
@@ -20,4 +20,6 @@ description: |-
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
 
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL

--- a/docs/resources/mongo.md
+++ b/docs/resources/mongo.md
@@ -18,5 +18,3 @@ description: |-
 ### Required
 
 - `service_name` (String) Service name to create
-
-

--- a/docs/resources/mongo_link.md
+++ b/docs/resources/mongo_link.md
@@ -20,4 +20,6 @@ description: |-
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
 
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -18,5 +18,3 @@ description: |-
 ### Required
 
 - `service_name` (String) Service name to create
-
-

--- a/docs/resources/mysql_link.md
+++ b/docs/resources/mysql_link.md
@@ -20,4 +20,6 @@ description: |-
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
 
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL

--- a/docs/resources/nats.md
+++ b/docs/resources/nats.md
@@ -22,5 +22,3 @@ description: |-
 ### Optional
 
 - `config_options` (String) Config options to create service with
-
-

--- a/docs/resources/nats_link.md
+++ b/docs/resources/nats_link.md
@@ -20,4 +20,6 @@ description: |-
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
 
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL

--- a/docs/resources/plugin.md
+++ b/docs/resources/plugin.md
@@ -19,5 +19,3 @@ description: |-
 
 - `name` (String) Name of plugin to install
 - `url` (String) URL of plugin to install
-
-

--- a/docs/resources/postgres_link.md
+++ b/docs/resources/postgres_link.md
@@ -35,6 +35,10 @@ resource "dokku_postgres_link" "demo" {
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
+
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL
+
 ## Import
 
 Import is supported using the following syntax:

--- a/docs/resources/postgres_link.md
+++ b/docs/resources/postgres_link.md
@@ -24,6 +24,7 @@ resource "dokku_app" "demo" {
 resource "dokku_postgres_link" "demo" {
   app_name     = "demo-app"
   service_name = "demo-service"
+  alias        = "DATABASE"
 }
 ```
 

--- a/docs/resources/rabbitmq.md
+++ b/docs/resources/rabbitmq.md
@@ -18,5 +18,3 @@ description: |-
 ### Required
 
 - `service_name` (String) Service name to create
-
-

--- a/docs/resources/rabbitmq_link.md
+++ b/docs/resources/rabbitmq_link.md
@@ -20,4 +20,6 @@ description: |-
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
 
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -18,5 +18,3 @@ description: |-
 ### Required
 
 - `service_name` (String) Service name to create
-
-

--- a/docs/resources/redis_link.md
+++ b/docs/resources/redis_link.md
@@ -20,4 +20,6 @@ description: |-
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
 
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL

--- a/docs/resources/rethinkdb.md
+++ b/docs/resources/rethinkdb.md
@@ -18,5 +18,3 @@ description: |-
 ### Required
 
 - `service_name` (String) Service name to create
-
-

--- a/docs/resources/rethinkdb_link.md
+++ b/docs/resources/rethinkdb_link.md
@@ -20,4 +20,6 @@ description: |-
 - `app_name` (String) App name to apply link service to
 - `service_name` (String) Service name to link
 
+### Optional
 
+- `alias` (String) Alias is dokku's resource alias to provide as env XXXX_URL

--- a/examples/resources/dokku_postgres_link/resource.tf
+++ b/examples/resources/dokku_postgres_link/resource.tf
@@ -9,4 +9,5 @@ resource "dokku_app" "demo" {
 resource "dokku_postgres_link" "demo" {
   app_name     = "demo-app"
   service_name = "demo-service"
+  alias        = "DATABASE"
 }

--- a/internal/provider/dokku_client/helper.go
+++ b/internal/provider/dokku_client/helper.go
@@ -3,5 +3,5 @@ package dokkuclient
 import "fmt"
 
 func DoubleDashArg[T any](key string, value T) string {
-	return fmt.Sprintf("--%s=%s", key, value)
+	return fmt.Sprintf("--%s %s", key, value)
 }

--- a/internal/provider/dokku_client/helper.go
+++ b/internal/provider/dokku_client/helper.go
@@ -1,0 +1,7 @@
+package dokkuclient
+
+import "fmt"
+
+func DoubleLineArg[T any](key string, value T) string {
+	return fmt.Sprintf("--%s=%s", key, value)
+}

--- a/internal/provider/dokku_client/helper.go
+++ b/internal/provider/dokku_client/helper.go
@@ -2,6 +2,6 @@ package dokkuclient
 
 import "fmt"
 
-func DoubleLineArg[T any](key string, value T) string {
+func DoubleDashArg[T any](key string, value T) string {
 	return fmt.Sprintf("--%s=%s", key, value)
 }

--- a/internal/provider/dokku_client/simple_service_link.go
+++ b/internal/provider/dokku_client/simple_service_link.go
@@ -20,8 +20,8 @@ func (c *Client) SimpleServiceLinkExists(ctx context.Context, servicePluginName 
 	return true, nil
 }
 
-func (c *Client) SimpleServiceLinkCreate(ctx context.Context, servicePluginName string, serviceName string, appName string) error {
-	_, _, err := c.RunQuiet(ctx, fmt.Sprintf("%s:link %s %s", servicePluginName, serviceName, appName))
+func (c *Client) SimpleServiceLinkCreate(ctx context.Context, servicePluginName string, serviceName string, appName string, args ...string) error {
+	_, _, err := c.RunQuiet(ctx, fmt.Sprintf("%s:link %s %s %s", servicePluginName, serviceName, appName, strings.Join(args, " ")))
 	return err
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -270,7 +270,7 @@ func (p *dokkuProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		return
 	}
 
-	testedVersions := ">=0.24.0 <=0.32.0"
+	testedVersions := ">=0.24.0 < 0.33.0"
 	testedErrMsg := fmt.Sprintf("This provider has not been tested against Dokku version %s. Tested version range: %s", rawVersion, testedVersions)
 
 	if err == nil {

--- a/internal/provider/services/clickhouse_link_resource.go
+++ b/internal/provider/services/clickhouse_link_resource.go
@@ -82,6 +82,9 @@ func (r *clickhouseLinkResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/clickhouse_link_resource.go
+++ b/internal/provider/services/clickhouse_link_resource.go
@@ -80,7 +80,7 @@ func (r *clickhouseLinkResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/clickhouse_link_resource.go
+++ b/internal/provider/services/clickhouse_link_resource.go
@@ -161,7 +161,7 @@ func (r *clickhouseLinkResource) Create(ctx context.Context, req resource.Create
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/clickhouse_link_resource.go
+++ b/internal/provider/services/clickhouse_link_resource.go
@@ -34,6 +34,7 @@ type clickhouseLinkResource struct {
 type clickhouseLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *clickhouseLinkResource) Schema(_ context.Context, _ resource.SchemaRequ
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *clickhouseLinkResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "clickhouse", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "clickhouse", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create clickhouse link", "Unable to create clickhouse link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *clickhouseLinkResource) ImportState(ctx context.Context, req resource.I
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }

--- a/internal/provider/services/clickhouse_link_resource.go
+++ b/internal/provider/services/clickhouse_link_resource.go
@@ -80,7 +80,7 @@ func (r *clickhouseLinkResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/couchdb_link_resource.go
+++ b/internal/provider/services/couchdb_link_resource.go
@@ -161,7 +161,7 @@ func (r *couchDBLinkResource) Create(ctx context.Context, req resource.CreateReq
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/couchdb_link_resource.go
+++ b/internal/provider/services/couchdb_link_resource.go
@@ -80,7 +80,7 @@ func (r *couchDBLinkResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/couchdb_link_resource.go
+++ b/internal/provider/services/couchdb_link_resource.go
@@ -80,7 +80,7 @@ func (r *couchDBLinkResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/couchdb_link_resource.go
+++ b/internal/provider/services/couchdb_link_resource.go
@@ -82,6 +82,9 @@ func (r *couchDBLinkResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/couchdb_link_resource.go
+++ b/internal/provider/services/couchdb_link_resource.go
@@ -34,6 +34,7 @@ type couchDBLinkResource struct {
 type couchDBLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *couchDBLinkResource) Schema(_ context.Context, _ resource.SchemaRequest
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *couchDBLinkResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "couchdb", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "couchdb", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create couchDB link", "Unable to create couchDB link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *couchDBLinkResource) ImportState(ctx context.Context, req resource.Impo
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }

--- a/internal/provider/services/elasticsearch_link_resource.go
+++ b/internal/provider/services/elasticsearch_link_resource.go
@@ -80,7 +80,7 @@ func (r *elasticsearchLinkResource) Schema(_ context.Context, _ resource.SchemaR
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/elasticsearch_link_resource.go
+++ b/internal/provider/services/elasticsearch_link_resource.go
@@ -34,6 +34,7 @@ type elasticsearchLinkResource struct {
 type elasticsearchLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *elasticsearchLinkResource) Schema(_ context.Context, _ resource.SchemaR
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *elasticsearchLinkResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "elasticsearch", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "elasticsearch", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create elasticsearch link", "Unable to create elasticsearch link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *elasticsearchLinkResource) ImportState(ctx context.Context, req resourc
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }

--- a/internal/provider/services/elasticsearch_link_resource.go
+++ b/internal/provider/services/elasticsearch_link_resource.go
@@ -161,7 +161,7 @@ func (r *elasticsearchLinkResource) Create(ctx context.Context, req resource.Cre
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/elasticsearch_link_resource.go
+++ b/internal/provider/services/elasticsearch_link_resource.go
@@ -82,6 +82,9 @@ func (r *elasticsearchLinkResource) Schema(_ context.Context, _ resource.SchemaR
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/elasticsearch_link_resource.go
+++ b/internal/provider/services/elasticsearch_link_resource.go
@@ -80,7 +80,7 @@ func (r *elasticsearchLinkResource) Schema(_ context.Context, _ resource.SchemaR
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/mariadb_link_resource.go
+++ b/internal/provider/services/mariadb_link_resource.go
@@ -80,7 +80,7 @@ func (r *mariaDBLinkResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/mariadb_link_resource.go
+++ b/internal/provider/services/mariadb_link_resource.go
@@ -80,7 +80,7 @@ func (r *mariaDBLinkResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/mariadb_link_resource.go
+++ b/internal/provider/services/mariadb_link_resource.go
@@ -82,6 +82,9 @@ func (r *mariaDBLinkResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/mariadb_link_resource.go
+++ b/internal/provider/services/mariadb_link_resource.go
@@ -34,6 +34,7 @@ type mariaDBLinkResource struct {
 type mariaDBLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *mariaDBLinkResource) Schema(_ context.Context, _ resource.SchemaRequest
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *mariaDBLinkResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "mariadb", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "mariadb", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create mariaDB link", "Unable to create mariaDB link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *mariaDBLinkResource) ImportState(ctx context.Context, req resource.Impo
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }

--- a/internal/provider/services/mariadb_link_resource.go
+++ b/internal/provider/services/mariadb_link_resource.go
@@ -161,7 +161,7 @@ func (r *mariaDBLinkResource) Create(ctx context.Context, req resource.CreateReq
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/mongo_link_resource.go
+++ b/internal/provider/services/mongo_link_resource.go
@@ -82,6 +82,9 @@ func (r *mongoLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/mongo_link_resource.go
+++ b/internal/provider/services/mongo_link_resource.go
@@ -80,7 +80,7 @@ func (r *mongoLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/mongo_link_resource.go
+++ b/internal/provider/services/mongo_link_resource.go
@@ -80,7 +80,7 @@ func (r *mongoLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/mongo_link_resource.go
+++ b/internal/provider/services/mongo_link_resource.go
@@ -34,6 +34,7 @@ type mongoLinkResource struct {
 type mongoLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *mongoLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *mongoLinkResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "mongo", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "mongo", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create mongo link", "Unable to create mongo link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *mongoLinkResource) ImportState(ctx context.Context, req resource.Import
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }

--- a/internal/provider/services/mongo_link_resource.go
+++ b/internal/provider/services/mongo_link_resource.go
@@ -161,7 +161,7 @@ func (r *mongoLinkResource) Create(ctx context.Context, req resource.CreateReque
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/mysql_link_resource.go
+++ b/internal/provider/services/mysql_link_resource.go
@@ -82,6 +82,9 @@ func (r *mysqlLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/mysql_link_resource.go
+++ b/internal/provider/services/mysql_link_resource.go
@@ -80,7 +80,7 @@ func (r *mysqlLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/mysql_link_resource.go
+++ b/internal/provider/services/mysql_link_resource.go
@@ -80,7 +80,7 @@ func (r *mysqlLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/mysql_link_resource.go
+++ b/internal/provider/services/mysql_link_resource.go
@@ -161,7 +161,7 @@ func (r *mysqlLinkResource) Create(ctx context.Context, req resource.CreateReque
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/mysql_link_resource.go
+++ b/internal/provider/services/mysql_link_resource.go
@@ -34,6 +34,7 @@ type mysqlLinkResource struct {
 type mysqlLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *mysqlLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *mysqlLinkResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "mysql", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "mysql", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create mysql link", "Unable to create mysql link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *mysqlLinkResource) ImportState(ctx context.Context, req resource.Import
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }

--- a/internal/provider/services/nats_link_resource.go
+++ b/internal/provider/services/nats_link_resource.go
@@ -80,7 +80,7 @@ func (r *natsLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/nats_link_resource.go
+++ b/internal/provider/services/nats_link_resource.go
@@ -80,7 +80,7 @@ func (r *natsLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/nats_link_resource.go
+++ b/internal/provider/services/nats_link_resource.go
@@ -161,7 +161,7 @@ func (r *natsLinkResource) Create(ctx context.Context, req resource.CreateReques
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/nats_link_resource.go
+++ b/internal/provider/services/nats_link_resource.go
@@ -82,6 +82,9 @@ func (r *natsLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/nats_link_resource.go
+++ b/internal/provider/services/nats_link_resource.go
@@ -34,6 +34,7 @@ type natsLinkResource struct {
 type natsLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *natsLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *natsLinkResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "nats", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "nats", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create nats link", "Unable to create nats link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *natsLinkResource) ImportState(ctx context.Context, req resource.ImportS
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }

--- a/internal/provider/services/postgres_link_resource.go
+++ b/internal/provider/services/postgres_link_resource.go
@@ -82,6 +82,9 @@ func (r *postgresLinkResource) Schema(_ context.Context, _ resource.SchemaReques
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/postgres_link_resource.go
+++ b/internal/provider/services/postgres_link_resource.go
@@ -161,7 +161,7 @@ func (r *postgresLinkResource) Create(ctx context.Context, req resource.CreateRe
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/postgres_link_resource.go
+++ b/internal/provider/services/postgres_link_resource.go
@@ -34,6 +34,7 @@ type postgresLinkResource struct {
 type postgresLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *postgresLinkResource) Schema(_ context.Context, _ resource.SchemaReques
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *postgresLinkResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "postgres", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "postgres", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create postgres link", "Unable to create postgres link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *postgresLinkResource) ImportState(ctx context.Context, req resource.Imp
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }

--- a/internal/provider/services/postgres_link_resource.go
+++ b/internal/provider/services/postgres_link_resource.go
@@ -80,7 +80,7 @@ func (r *postgresLinkResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/postgres_link_resource.go
+++ b/internal/provider/services/postgres_link_resource.go
@@ -80,7 +80,7 @@ func (r *postgresLinkResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/rabbitmq_link_resource.go
+++ b/internal/provider/services/rabbitmq_link_resource.go
@@ -80,7 +80,7 @@ func (r *rabbitMQLinkResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/rabbitmq_link_resource.go
+++ b/internal/provider/services/rabbitmq_link_resource.go
@@ -34,6 +34,7 @@ type rabbitMQLinkResource struct {
 type rabbitMQLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *rabbitMQLinkResource) Schema(_ context.Context, _ resource.SchemaReques
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *rabbitMQLinkResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "rabbitmq", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "rabbitmq", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create rabbitMQ link", "Unable to create rabbitMQ link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *rabbitMQLinkResource) ImportState(ctx context.Context, req resource.Imp
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }

--- a/internal/provider/services/rabbitmq_link_resource.go
+++ b/internal/provider/services/rabbitmq_link_resource.go
@@ -80,7 +80,7 @@ func (r *rabbitMQLinkResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/rabbitmq_link_resource.go
+++ b/internal/provider/services/rabbitmq_link_resource.go
@@ -82,6 +82,9 @@ func (r *rabbitMQLinkResource) Schema(_ context.Context, _ resource.SchemaReques
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/rabbitmq_link_resource.go
+++ b/internal/provider/services/rabbitmq_link_resource.go
@@ -161,7 +161,7 @@ func (r *rabbitMQLinkResource) Create(ctx context.Context, req resource.CreateRe
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/redis_link_resource.go
+++ b/internal/provider/services/redis_link_resource.go
@@ -161,7 +161,7 @@ func (r *redisLinkResource) Create(ctx context.Context, req resource.CreateReque
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/redis_link_resource.go
+++ b/internal/provider/services/redis_link_resource.go
@@ -80,7 +80,7 @@ func (r *redisLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/redis_link_resource.go
+++ b/internal/provider/services/redis_link_resource.go
@@ -34,6 +34,7 @@ type redisLinkResource struct {
 type redisLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *redisLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *redisLinkResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "redis", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "redis", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create redis link", "Unable to create redis link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *redisLinkResource) ImportState(ctx context.Context, req resource.Import
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }

--- a/internal/provider/services/redis_link_resource.go
+++ b/internal/provider/services/redis_link_resource.go
@@ -80,7 +80,7 @@ func (r *redisLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/redis_link_resource.go
+++ b/internal/provider/services/redis_link_resource.go
@@ -82,6 +82,9 @@ func (r *redisLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/rethinkdb_link_resource.go
+++ b/internal/provider/services/rethinkdb_link_resource.go
@@ -80,7 +80,7 @@ func (r *rethinkDBLinkResource) Schema(_ context.Context, _ resource.SchemaReque
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/rethinkdb_link_resource.go
+++ b/internal/provider/services/rethinkdb_link_resource.go
@@ -161,7 +161,7 @@ func (r *rethinkDBLinkResource) Create(ctx context.Context, req resource.CreateR
 
 	args := make([]string, 0)
 	if !plan.Alias.IsNull() {
-		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+		args = append(args, dokkuclient.DoubleDashArg("alias", plan.Alias.ValueString()))
 	}
 
 	// Create link

--- a/internal/provider/services/rethinkdb_link_resource.go
+++ b/internal/provider/services/rethinkdb_link_resource.go
@@ -80,7 +80,7 @@ func (r *rethinkDBLinkResource) Schema(_ context.Context, _ resource.SchemaReque
 				Optional:    true,
 				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]*$`), "invalid alias"),
 				},
 			},
 		},

--- a/internal/provider/services/rethinkdb_link_resource.go
+++ b/internal/provider/services/rethinkdb_link_resource.go
@@ -82,6 +82,9 @@ func (r *rethinkDBLinkResource) Schema(_ context.Context, _ resource.SchemaReque
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z_]+$`), "invalid alias"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}

--- a/internal/provider/services/rethinkdb_link_resource.go
+++ b/internal/provider/services/rethinkdb_link_resource.go
@@ -34,6 +34,7 @@ type rethinkDBLinkResource struct {
 type rethinkDBLinkResourceModel struct {
 	AppName     types.String `tfsdk:"app_name"`
 	ServiceName types.String `tfsdk:"service_name"`
+	Alias       types.String `tfsdk:"alias"`
 }
 
 // Metadata returns the resource type name.
@@ -73,6 +74,13 @@ func (r *rethinkDBLinkResource) Schema(_ context.Context, _ resource.SchemaReque
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9-]*$`), "invalid service_name"),
+				},
+			},
+			"alias": schema.StringAttribute{
+				Optional:    true,
+				Description: "Alias is dokku's resource alias to provide as env XXXX_URL",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z]*$`), "invalid alias"),
 				},
 			},
 		},
@@ -151,8 +159,13 @@ func (r *rethinkDBLinkResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	args := make([]string, 0)
+	if !plan.Alias.IsNull() {
+		args = append(args, dokkuclient.DoubleLineArg("alias", plan.Alias.ValueString()))
+	}
+
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "rethinkdb", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	err = r.client.SimpleServiceLinkCreate(ctx, "rethinkdb", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create rethinkDB link", "Unable to create rethinkDB link. "+err.Error())
 		return
@@ -213,4 +226,7 @@ func (r *rethinkDBLinkResource) ImportState(ctx context.Context, req resource.Im
 	parts := strings.Split(req.ID, " ")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[1])...)
+	if len(parts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alias"), parts[2])...)
+	}
 }


### PR DESCRIPTION
This commit introduces an alias option into multiple services including Elasticsearch, MongoDB, Clickhouse, and many others. The alias option is optional, validated for an uppercase string, and helper function has been updated to facilitate this change. Furthermore, logic around creating service links have also been modified to account for the possible presence of an alias.